### PR TITLE
#30 英語の場合、日付の表示の逆順設定をやめる

### DIFF
--- a/Hakenman/screen/menu/HistoryEditViewController.m
+++ b/Hakenman/screen/menu/HistoryEditViewController.m
@@ -161,16 +161,8 @@
     
     // PickerViewの初期の選択値を設定
     // componentが行番号、selectRowが列番号
-    //英語の場合は日付の表示が逆順
-    if ([[self checkCurrentLanguage]isEqualToString:@"ja"]||
-        [[self checkCurrentLanguage]isEqualToString:@"kr"]) {
-        [self.pickerView selectRow:rowOfTodayYear inComponent:0 animated:YES];
-        [self.pickerView selectRow:rowOfTodayMonth inComponent:2 animated:YES];
-    }else{
-        [self.pickerView selectRow:rowOfTodayMonth inComponent:0 animated:YES];
-        [self.pickerView selectRow:rowOfTodayYear inComponent:2 animated:YES];
-        
-    }
+    [self.pickerView selectRow:rowOfTodayYear inComponent:0 animated:YES];
+    [self.pickerView selectRow:rowOfTodayMonth inComponent:2 animated:YES];
 }
 
 - (void)_addThePast{


### PR DESCRIPTION
**不具合**
過去のデータ作成、削除の画面のPickerViewの初期値が2014年になっている

**原因**
端末の言語が日本語と韓国語を判断するところが
きちんと判断できていなかった（国家コードが違う）
日本：ja -> ja-US
韓国：kr -> ko-US

**解決**
`isEqualToString`ではなく、`hasPrefix`で判断するように修正

**結果**
英語の場合年と月の表示が逆順のため実装されている機能だが、
実際にPickerViewの表示を変える処理がないため、
修正しても英語の場合不具合が発生する
そのため、一応端末言語を判断する機能を削除