### PR TITLE
#40 過去データ作成後、画面更新対応

### DIFF
--- a/Hakenman/screen/top/TopViewController.m
+++ b/Hakenman/screen/top/TopViewController.m
@@ -272,8 +272,7 @@ static NSString * const kMonthCellIdentifier = @"monthCellIdentifier";
     [_menuBarButton addTarget:self action:@selector(gotoMenuButtonTouched:)
              forControlEvents:UIControlEventTouchUpInside];
     
-    //HACK: この機能の動作がおかしいので修正する前までメニューからなくす。　j.lee
-    //[self.navigationController.navigationBar addSubview:_menuBarButton];
+    [self.navigationController.navigationBar addSubview:_menuBarButton];
     
     _settingBarButton = [[PBBarButtonIconButton alloc] initWithFrame:CGRectMake(self.navigationController.navigationBar.frame.size.width - 40, 5, 35, 35)
                                                          andWithType:PBFlatIconMore];
@@ -305,6 +304,8 @@ static NSString * const kMonthCellIdentifier = @"monthCellIdentifier";
     
     //push Animation
 
+    
+    instantiateInitialViewController.modalPresentationStyle = UIModalPresentationFullScreen;
     
     [self presentViewController:instantiateInitialViewController animated:YES completion:^{
         

--- a/Hakenman/screen/top/TopViewController.m
+++ b/Hakenman/screen/top/TopViewController.m
@@ -272,7 +272,8 @@ static NSString * const kMonthCellIdentifier = @"monthCellIdentifier";
     [_menuBarButton addTarget:self action:@selector(gotoMenuButtonTouched:)
              forControlEvents:UIControlEventTouchUpInside];
     
-    [self.navigationController.navigationBar addSubview:_menuBarButton];
+    //HACK: この機能の動作がおかしいので修正する前までメニューからなくす。　j.lee
+    //[self.navigationController.navigationBar addSubview:_menuBarButton];
     
     _settingBarButton = [[PBBarButtonIconButton alloc] initWithFrame:CGRectMake(self.navigationController.navigationBar.frame.size.width - 40, 5, 35, 35)
                                                          andWithType:PBFlatIconMore];


### PR DESCRIPTION
### 概要

~~過去勤務シートを作成する処理が間違っている。
一旦機能を削除してあとで対応する。~~

viewWillAppearが呼ばれてなかったため。

### 修正点

~~過去シート作成メニューを削除~~

iOS13のmodal presentが原因。直した。

### その他

Pickerの挙動が間違っているため、#30と一緒に対応が必要。