### PR TITLE
#41 ダークモードの場合、当月のチャートの値の文字色が黒なので見えない

### DIFF
--- a/Hakenman.xcodeproj/project.pbxproj
+++ b/Hakenman.xcodeproj/project.pbxproj
@@ -744,10 +744,9 @@
 			};
 			buildConfigurationList = 3B469F9318B89D3A0095C418 /* Build configuration list for PBXProject "Hakenman" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 				ja,

--- a/Hakenman/Images.xcassets/darkmode/graphTextColor.colorset/Contents.json
+++ b/Hakenman/Images.xcassets/darkmode/graphTextColor.colorset/Contents.json
@@ -1,0 +1,78 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "140",
+          "alpha" : "1.000",
+          "blue" : "140",
+          "green" : "140"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "255",
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.549",
+          "alpha" : "1.000",
+          "blue" : "0.549",
+          "green" : "0.549"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        },
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Hakenman/screen/top/LineGraphView.m
+++ b/Hakenman/screen/top/LineGraphView.m
@@ -45,7 +45,7 @@
         self.backgroundColor = [UIColor clearColor];
         self.noDataLabel = [[UILabel alloc] initWithFrame:self.bounds];
         _noDataLabel.text = LOCALIZE(@"LineGraphView_total_work_day_no_data");
-        _noDataLabel.textColor = [UIColor lightGrayColor];
+		_noDataLabel.textColor = [UIColor colorNamed:@"graphTextColor"];
         _noDataLabel.textAlignment = NSTextAlignmentCenter;
         _noDataLabel.font = [UIFont nanumFontOfSize:36.f];
         [self addSubview:_noDataLabel];
@@ -270,7 +270,7 @@
     [[UIColor redColor] setFill]; // This is the default
     
     [t drawAtPoint:CGPointMake(p.x, p.y)
-               withAttributes:@{NSFontAttributeName:[UIFont nanumFontOfSize:5.f]}];
+	withAttributes:@{NSFontAttributeName:[UIFont nanumFontOfSize:9.f], NSForegroundColorAttributeName:[UIColor colorNamed:@"graphTextColor"]}];
     
 }
 


### PR DESCRIPTION
・ダークモード時のトップ画面のグラフテキスト色を明るく対応。
・プロジェクト設定の国際化設定警告対応。